### PR TITLE
feat: fix and upgrade to quince

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info/
 /build/
 /dist/
+.DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
     TUTOR_PLUGIN: webui
     TUTOR_PYPI_PACKAGE: tutor-webui
-    OPENEDX_RELEASE: palm
+    OPENEDX_RELEASE: quince
     GITHUB_REPO: overhangio/tutor-webui
 
 include:

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=16.0.0,<17.0.0", "click_repl>=0.3.0"],
+    install_requires=["tutor>=17.0.0,<18.0.0", "click_repl>=0.3.0"],
     entry_points={
         "tutor.plugin.v1": ["webui = tutorwebui.plugin"],
     },

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=16.0.0,<17.0.0", "click_repl>=0.2.0"],
+    install_requires=["tutor>=16.0.0,<17.0.0", "click_repl>=0.3.0"],
     entry_points={
         "tutor.plugin.v1": ["webui = tutorwebui.plugin"],
     },

--- a/tutorwebui/__about__.py
+++ b/tutorwebui/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "16.0.0"
+__version__ = "17.0.0"
 __package_version__ = __version__
 
 # Handle version suffix for nightly, just like tutor core.

--- a/tutorwebui/cli.py
+++ b/tutorwebui/cli.py
@@ -113,9 +113,8 @@ Type "help" to view all available commands.
 Type "local launch" to configure and launch a new platform from scratch.
 Type <ctrl-d> to exit."""
     )
-    # We need to manually patch the TutorCli object because click_repl
-    # incorrectly calls the `commands` attribute. Note that this enables us to
-    # run shell within shell, which is cool but a little weird...
+    # Retrieve the current Click context. The context is used to manage the state
+    # and pass around internal objects within the Click framework.
     ctx = click.get_current_context()
     
     while True:

--- a/tutorwebui/cli.py
+++ b/tutorwebui/cli.py
@@ -117,8 +117,7 @@ Type <ctrl-d> to exit."""
     # incorrectly calls the `commands` attribute. Note that this enables us to
     # run shell within shell, which is cool but a little weird...
     ctx = click.get_current_context()
-    ctx.parent.command.commands = {}
-
+    
     while True:
         try:
             click_repl.repl(ctx)


### PR DESCRIPTION
**Description**: Upgrading the tutor web plugin to quince.

**Updates made** :
- Removed the line **ctx.parent.command.commands = {}** from cli.py, causing issues in webui shell.
- Updated the **click repl version to latest 0.3.0**
- Updated version of plugin form **16.0.0 to 17.0.0**
- Updated release from **palm to quince**
- **Added DS_store in gitignore** which is added by  macOS to prevent unnecessary file commit  
