### PR TITLE
fix: corrected click context management in TutorCli, resolves #14

### DIFF
--- a/changelog.d/20240326_115811_abdul.muqadim_fix_click_context_management.md
+++ b/changelog.d/20240326_115811_abdul.muqadim_fix_click_context_management.md
@@ -1,0 +1,1 @@
+- [Improvement]  This is a non-breaking change. Removed unnecessary command clearing in context parent, simplifying the context handling. (by @Abdul-Muqadim-Arbisoft)

--- a/tutorwebui/cli.py
+++ b/tutorwebui/cli.py
@@ -116,9 +116,7 @@ Type <ctrl-d> to exit."""
     # Retrieve the current Click context. The context is used to manage the state
     # and pass around internal objects within the Click framework.
     ctx = click.get_current_context()
-    if ctx.parent and ctx.parent.command:
-        ctx.parent.command.commands = {}  # type: ignore
-
+    
     while True:
         try:
             click_repl.repl(ctx)

--- a/tutorwebui/cli.py
+++ b/tutorwebui/cli.py
@@ -116,7 +116,7 @@ Type <ctrl-d> to exit."""
     # Retrieve the current Click context. The context is used to manage the state
     # and pass around internal objects within the Click framework.
     ctx = click.get_current_context()
-    
+
     while True:
         try:
             click_repl.repl(ctx)


### PR DESCRIPTION
 Removed manual patching of TutorCli object to address an issue where `click_repl` incorrectly accessed the `commands` attribute. This patch previously enabled nested shell functionality, which introduced complexity and unexpected behavior.